### PR TITLE
Update SliderField.js

### DIFF
--- a/javascript/SliderField.js
+++ b/javascript/SliderField.js
@@ -1,4 +1,3 @@
-
 (function($){
 	$.entwine('ss', function($) {
 		$('input.slider').entwine({
@@ -12,7 +11,7 @@
 				return this.data('orientation');
 			},
 			limitValue: function() {
-				val = parseInt(this.val());
+				val = parseInt(this.val()) || this.getMin();
 				val = Math.max(this.getMin(), Math.min(this.getMax(), val));
 				this.val(val);
 				return val;


### PR DESCRIPTION
If defaults are set to 0, Silverstripe seems to return an empty string, and the number was then failing validation as NaN. My solution is to suggest if false (NaN) instead make the number the min.
