### PR TITLE
BUGFIX: Using values larger then 999

### DIFF
--- a/javascript/SliderField.js
+++ b/javascript/SliderField.js
@@ -12,6 +12,7 @@
 				return this.data('orientation');
 			},
 			limitValue: function() {
+				val = this.val().replace(/,/g, "");
 				val = parseInt(this.val());
 				if(isNaN(val)) val = 0;
 				val = Math.max(this.getMin(), Math.min(this.getMax(), val));


### PR DESCRIPTION
Fixes issue when using a value bigger then 999. After saving with a value over 999, the value might look like 1,001. parseInt wasn't parsing correctly (because of the comma) resulting in the value being reset to the slider min-value.
