### PR TITLE
Fix incorrect values for numbers over 999

### DIFF
--- a/javascript/SliderField.js
+++ b/javascript/SliderField.js
@@ -19,8 +19,8 @@
 				return val;
 			},
 			getCleanVal: function(){
-				return parseInt(this.val().replace(/,/g, ""))
-			}
+				return parseInt(this.val().replace(/,/g, ""));
+			},
 			onmatch: function() {
 				var self = this;
 				var val = self.limitValue();

--- a/javascript/SliderField.js
+++ b/javascript/SliderField.js
@@ -12,11 +12,15 @@
 				return this.data('orientation');
 			},
 			limitValue: function() {
-				val = parseInt(this.val());
+				var val = this.getCleanVal();
+				if(isNaN(val)) val = 0;
 				val = Math.max(this.getMin(), Math.min(this.getMax(), val));
 				this.val(val);
 				return val;
 			},
+			getCleanVal: function(){
+				return parseInt(this.val().replace(/,/g, ""))
+			}
 			onmatch: function() {
 				var self = this;
 				var val = self.limitValue();


### PR DESCRIPTION
Run regex to strip out commas from numbers before running parseInt()

https://github.com/tractorcow/silverstripe-sliderfield/issues/9
