### PR TITLE
allow install on framework-only projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "silverstripe/vendor-plugin": "^1.0",
-        "silverstripe/cms": "^4.0"
+        "silverstripe/admin": "^1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since there is no hard dependancies on CMS related classes or functions this should work fine with any admin.